### PR TITLE
fix: wrong function name was used in docs, now it is fixed

### DIFF
--- a/docs/usage_guide/error_handling.md
+++ b/docs/usage_guide/error_handling.md
@@ -22,7 +22,7 @@ final agent = await Agent.create(
   llm: llm,
   name: 'assistant',
   role: 'A helpful assistant.',
-  failureMode: FailureMode.throwException,
+  failureMode: FailureMode.throwError,
 );
 ```
 
@@ -45,7 +45,7 @@ if (response.isError) {
 }
 ```
 
-### `FailureMode.throwException`
+### `FailureMode.throwError`
 
 Exceptions propagate to your code. Use this when you want full control over error handling:
 
@@ -184,7 +184,7 @@ class ResilientService {
       ),
       name: 'primary',
       role: 'A helpful assistant.',
-      failureMode: FailureMode.throwException,
+      failureMode: FailureMode.throwError,
       scope: scope,
     );
 


### PR DESCRIPTION
# Name Patch

## Description
The docs used `throwException` instead of the correct `throwError`. This has now been fixed.

## Changes
- [ ] Breaking Change
- [ ] Bug Fix
- [ ] Additional Feature
- [x] Doc updates

## Checklist
- [x] `dart format` clean
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` green; new code covered
- [x] CHANGELOG updated if user-facing
- [x] Public API changes exported from `lib/agenix.dart` and documented

## Issue Linked to the PR
n/a
## Additional Information
n/a