### PR TITLE
Fix/improving restrictions on tool chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ The core `agenix` package ships with `DataStore.inMemory()` — a zero-dependenc
 ```yaml
 # Core only (no Firebase):
 dependencies:
-  agenix: ^4.1.1
+  agenix: ^4.1.2
 
 # With Firebase persistence:
 dependencies:
-  agenix: ^4.1.1
-  agenix_firebase: ^1.0.3
+  agenix: ^4.1.2
+  agenix_firebase: ^1.0.4
 ```
 
 ```dart
@@ -119,13 +119,13 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  agenix: ^4.1.1
+  agenix: ^4.1.2
 ```
 
 If you need Firebase persistence, also add:
 
 ```yaml
-  agenix_firebase: ^1.0.3
+  agenix_firebase: ^1.0.4
 ```
 
 Then run:

--- a/docs/usage_guide/tools.md
+++ b/docs/usage_guide/tools.md
@@ -348,6 +348,42 @@ The LLM can invoke multiple tools in a single turn. For example, if a user asks 
 
 You don't need to do anything special to enable this. Just register your tools and the LLM will decide when to use multiple tools.
 
+## Tool Loop Safety
+
+Within a single turn, agenix enforces two guarantees so a stubborn model can't
+duplicate side effects or waste your LLM budget:
+
+1. **No duplicate `(tool, params)` execution.** Every invocation is keyed by
+   `(tool name + parameters JSON)`. If the model requests the same call again
+   in a later iteration — whether it succeeded or failed the first time —
+   the framework filters it out *before* `run()` is called.
+2. **Early return when nothing remains to do.** If a follow-up model turn
+   asks only for tools that have already been attempted, the loop exits
+   immediately with the joined success messages instead of doing another
+   LLM round trip.
+
+The observation prompt sent back to the model between iterations makes this
+explicit: succeeded calls are listed under an "already completed — the
+framework will REJECT re-invocations" section, failures under a "retry ONLY
+with corrected parameters" section. Well-behaved models respond as soon as
+the task is done; misbehaving models are hard-blocked by the filter.
+
+### Idempotency contract for side-effecting tools
+
+The framework can detect a *literal* duplicate — same tool, same parameters.
+It **cannot** detect semantic duplicates, e.g. the model calling
+`save_task({title: "rent"})` and then `save_task({title: "rent ", note: "retry"})`
+— those are different `(name, params)` keys, so both will run.
+
+If your tool has observable side effects (DB writes, external API calls,
+messages sent, payments), make it idempotent:
+
+- Prefer **upsert semantics** on a natural key (`title`, `user_id`, etc.).
+- Or accept an explicit **idempotency token** as a required parameter.
+- Or check for an existing record before inserting a new one.
+
+This contract is documented on `Tool.run()` and is the final line of defence.
+
 ## Best Practices
 
 1. **Name tools clearly.** Use `snake_case` verbs: `search_recipes`, `get_weather`, `send_email`. The LLM uses the name to decide when to call the tool.

--- a/packages/agenix/CHANGELOG.md
+++ b/packages/agenix/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.2
+- **Tool loop hardening** — the agent now hard-blocks re-execution of any `(tool, params)` combo already attempted in the same turn. If the LLM ignores the observation prompt and re-requests a succeeded tool, the framework filters it out before it reaches the tool's `run()` method, and if the whole batch is filtered to empty, the loop returns immediately with the accumulated success messages instead of burning more LLM calls. Fixes duplicate side effects (e.g. double-inserted DB rows) observed with strict instruction-following models that would otherwise repeat successful tool calls.
+- **Explicit succeeded/failed observation prompt** — the follow-up prompt now enumerates completed calls under a dedicated "already completed — the framework will REJECT re-invocations" section and failures under a "retry ONLY with corrected parameters" section, with an explicit directive to respond when nothing remains. Previously the raw observation JSON left "the task" looking unaddressed alongside the tool results.
+- **Documented idempotency contract** — the `Tool.run()` dartdoc now formally states that side-effecting tools should be idempotent (upsert semantics, natural key, or idempotency token), since framework-level dedup cannot detect semantically-equivalent calls with different parameter shapes.
+
 ## 4.1.1
 - Updated documentation to list all built-in LLM providers (Gemini, OpenAI, Anthropic, Groq, DeepSeek, Cohere, xAI) and clarify the custom LLM extension point.
 

--- a/packages/agenix/README.md
+++ b/packages/agenix/README.md
@@ -81,7 +81,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  agenix: ^4.1.1
+  agenix: ^4.1.2
 ```
 
 Then run:
@@ -96,8 +96,8 @@ The core package ships with `DataStore.inMemory()` — a zero-dependency store f
 
 ```yaml
 dependencies:
-  agenix: ^4.1.1
-  agenix_firebase: ^1.0.3
+  agenix: ^4.1.2
+  agenix_firebase: ^1.0.4
 ```
 
 See [`agenix_firebase`](https://pub.dev/packages/agenix_firebase) for setup instructions.
@@ -415,6 +415,17 @@ agent.toolRegistry.unregisterTool('weather_tool');
 | `message` | `String` | Human-readable result shown to the user |
 | `data` | `Map?` | Structured data for agent chaining or further reasoning |
 | `needsFurtherReasoning` | `bool` | When `true`, the agent makes a second LLM call to synthesize the tool output into a natural-language answer |
+
+#### Tool loop safety
+
+Within a single turn, the agent hard-blocks re-execution of any
+`(tool name, parameters)` combo that has already been attempted. If the LLM
+ignores instructions and re-requests a succeeded tool, the framework filters
+it out before `run()` is called; if the whole batch is filtered to empty, the
+loop returns immediately with the accumulated success messages instead of
+burning another LLM round trip. See
+[docs/usage_guide/tools.md](../../docs/usage_guide/tools.md#tool-loop-safety)
+for details, including the idempotency contract for side-effecting tools.
 
 ---
 

--- a/packages/agenix/lib/src/agent/agent.dart
+++ b/packages/agenix/lib/src/agent/agent.dart
@@ -207,6 +207,10 @@ class Agent {
 
     // Accumulated tool observations for multi-step tool use.
     final observations = <Map<String, dynamic>>[];
+    // Per-tool (name + params) keys that have already been attempted this turn.
+    // Used to hard-block re-execution — the model cannot repeat a call even if
+    // it ignores the observation prompt.
+    final attemptedCalls = <String>{};
     var currentPrompt = prompt;
     var isFirstCall = true;
 
@@ -240,8 +244,59 @@ class Agent {
           );
 
         case ParseOutcome.tools:
+          // Filter out any (tool, params) combo already attempted this turn.
+          // Prevents duplicate side effects even if the model ignores the
+          // observation prompt's "do not re-invoke" instruction.
+          final remaining = <String>[];
+          final remainingKeys = <String>[];
+          for (final toolName in parsed.toolNames) {
+            final key = json.encode({
+              'tool': toolName,
+              'params': parsed.params[toolName] ?? const <String, dynamic>{},
+            });
+            if (attemptedCalls.contains(key)) continue;
+            remaining.add(toolName);
+            remainingKeys.add(key);
+          }
+
+          if (remaining.isEmpty) {
+            // Model re-requested only already-attempted tools. Return with
+            // whatever we have so we don't burn more LLM calls.
+            final successMessages = observations
+                .where((o) => o['success'] == true)
+                .map((o) => (o['message'] ?? '').toString())
+                .where((m) => m.isNotEmpty)
+                .toList();
+            final content = successMessages.isNotEmpty
+                ? successMessages.join('\n')
+                : kLLMResponseOnFailure;
+            return AgentMessage(
+              content: content,
+              isFromAgent: true,
+              generatedAt: DateTime.now(),
+              data: observations.isNotEmpty
+                  ? {'observations': observations}
+                  : null,
+            );
+          }
+
+          // Mark as attempted BEFORE running so an exception mid-flight still
+          // blocks a naive retry of the same call.
+          attemptedCalls.addAll(remainingKeys);
+
+          final filteredParsed = PromptParserResult(
+            outcome: ParseOutcome.tools,
+            toolNames: remaining,
+            params: {
+              for (final t in remaining)
+                t: parsed.params[t] ?? const <String, dynamic>{},
+            },
+            agentNames: parsed.agentNames,
+            rawOutput: parsed.rawOutput,
+          );
+
           final toolResponses = await _toolRunner.runTools(
-            parsed,
+            filteredParsed,
             toolRegistry,
           );
 
@@ -262,8 +317,8 @@ class Agent {
             return _reasonUsingData(userMessage.content, toolResponses);
           }
 
-          // Build a follow-up prompt with observations so the LLM can
-          // decide whether to call more tools or produce a final response.
+          // Build a follow-up prompt with an explicit succeeded/failed split
+          // so the LLM knows exactly what remains and what NOT to repeat.
           currentPrompt = _buildObservationPrompt(
             originalPrompt: prompt,
             observations: observations,
@@ -329,11 +384,47 @@ class Agent {
     required String originalPrompt,
     required List<Map<String, dynamic>> observations,
   }) {
-    final observationJson = json.encode(observations);
-    return '$originalPrompt\n\n'
-        'Tool observations so far:\n$observationJson\n\n'
-        'Based on these observations, either call more tools if needed or '
-        'provide a final response in JSON format.';
+    final succeeded = observations.where((o) => o['success'] == true).toList();
+    final failed = observations.where((o) => o['success'] != true).toList();
+
+    final buffer = StringBuffer(originalPrompt);
+    buffer.writeln('\n\nTool execution results so far:');
+
+    if (succeeded.isNotEmpty) {
+      buffer.writeln(
+        '\nAlready completed successfully — the framework will REJECT any '
+        'attempt to invoke these again with the same parameters:',
+      );
+      for (final o in succeeded) {
+        buffer.writeln('- ${o['tool']}: ${o['message']}');
+      }
+    }
+
+    if (failed.isNotEmpty) {
+      buffer.writeln(
+        '\nFailed — you may retry ONLY with corrected parameters, or '
+        'acknowledge the failure in your response:',
+      );
+      for (final o in failed) {
+        buffer.writeln('- ${o['tool']}: ${o['message']}');
+      }
+    }
+
+    if (failed.isEmpty) {
+      buffer.writeln(
+        '\nAll requested actions are complete. If the user\'s task is fully '
+        'done, respond NOW with {"response": "<brief confirmation>"}. '
+        'Only call another tool if a DIFFERENT next step is genuinely required.',
+      );
+    } else {
+      buffer.writeln(
+        '\nDecide: call the next required tool, retry a failed one with '
+        'corrected params, or respond with {"response": "..."}. '
+        'Never re-invoke a succeeded tool.',
+      );
+    }
+
+    return buffer.toString().trim();
   }
 
   Future<AgentMessage> _handleAgentChain({

--- a/packages/agenix/lib/src/agent/agent.dart
+++ b/packages/agenix/lib/src/agent/agent.dart
@@ -262,21 +262,24 @@ class Agent {
           if (remaining.isEmpty) {
             // Model re-requested only already-attempted tools. Return with
             // whatever we have so we don't burn more LLM calls.
-            final successMessages = observations
-                .where((o) => o['success'] == true)
-                .map((o) => (o['message'] ?? '').toString())
-                .where((m) => m.isNotEmpty)
-                .toList();
-            final content = successMessages.isNotEmpty
-                ? successMessages.join('\n')
-                : kLLMResponseOnFailure;
+            final successMessages =
+                observations
+                    .where((o) => o['success'] == true)
+                    .map((o) => (o['message'] ?? '').toString())
+                    .where((m) => m.isNotEmpty)
+                    .toList();
+            final content =
+                successMessages.isNotEmpty
+                    ? successMessages.join('\n')
+                    : kLLMResponseOnFailure;
             return AgentMessage(
               content: content,
               isFromAgent: true,
               generatedAt: DateTime.now(),
-              data: observations.isNotEmpty
-                  ? {'observations': observations}
-                  : null,
+              data:
+                  observations.isNotEmpty
+                      ? {'observations': observations}
+                      : null,
             );
           }
 

--- a/packages/agenix/lib/src/tools/tool.dart
+++ b/packages/agenix/lib/src/tools/tool.dart
@@ -26,5 +26,13 @@ abstract class Tool {
   });
 
   /// Executes the tool with the given validated parameters.
+  ///
+  /// **Idempotency contract:** if this tool has observable side effects
+  /// (writes to a database, sends a message, charges a card), implementations
+  /// SHOULD be idempotent — use upsert semantics, a natural key, or an
+  /// explicit idempotency token in the parameters. The framework guards
+  /// against duplicate `(name, params)` invocations within a single turn,
+  /// but it cannot detect semantically-equivalent calls with different
+  /// parameter shapes, so this contract is the final line of defence.
   Future<ToolResponse> run(Map<String, dynamic> params);
 }

--- a/packages/agenix/pubspec.yaml
+++ b/packages/agenix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: agenix
 description: "Flutter framework for multi-agent AI orchestration. Build agents that use tools, chain tasks, and talk to each other. Works with any LLM provider & no backend is needed."
-version: 4.1.1
+version: 4.1.2
 homepage: https://github.com/ahmadexe/agenix
 repository: https://github.com/ahmadexe/agenix/tree/main/packages/agenix
 

--- a/packages/agenix/test/agent/agent_loop_test.dart
+++ b/packages/agenix/test/agent/agent_loop_test.dart
@@ -165,7 +165,9 @@ void main() {
       agent.dispose();
     });
 
-    test('max-iteration fallback synthesizes from observations', () async {
+    test('duplicate tool call is deduplicated and returns observations', () async {
+      // All responses request the same tool with identical params — dedup should
+      // fire on the second call (step 1) and return early with the observation.
       final responses = List.generate(
         kMaxToolIterations,
         (_) => '{"tools":"t","parameters":{"t":{}}}',
@@ -179,8 +181,9 @@ void main() {
         userMessage: userMsg('loop'),
       );
 
+      // Dedup fires after second LLM call sees the same tool+params combo.
       expect(res.content, contains('ok from t'));
-      expect(llm.callCount, kMaxToolIterations);
+      expect(llm.callCount, 2);
       agent.dispose();
     });
 

--- a/packages/agenix_firebase/CHANGELOG.md
+++ b/packages/agenix_firebase/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.4
+- Bumped `agenix` dependency to `^4.1.2`.
+
 ## 1.0.3
 - Bumped `agenix` dependency to `^4.1.1`.
 

--- a/packages/agenix_firebase/README.md
+++ b/packages/agenix_firebase/README.md
@@ -18,8 +18,8 @@ This package provides `FirebaseDataStore`, an implementation of `DataStore` that
 
 ```yaml
 dependencies:
-  agenix: ^4.1.1
-  agenix_firebase: ^1.0.3
+  agenix: ^4.1.2
+  agenix_firebase: ^1.0.4
 ```
 
 ```bash
@@ -129,8 +129,8 @@ In agenix 3.x, Firebase was bundled in the core package. In 4.0.0, it was extrac
 ```diff
 # pubspec.yaml
   dependencies:
-    agenix: ^4.1.1
-+   agenix_firebase: ^1.0.3
+    agenix: ^4.1.2
++   agenix_firebase: ^1.0.4
 
 # Dart
 + import 'package:agenix_firebase/agenix_firebase.dart';

--- a/packages/agenix_firebase/pubspec.yaml
+++ b/packages/agenix_firebase/pubspec.yaml
@@ -1,6 +1,6 @@
 name: agenix_firebase
 description: "Firebase (Firestore + Storage + Auth) data store backend for the agenix AI agent framework."
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/ahmadexe/agenix
 repository: https://github.com/ahmadexe/agenix/tree/main/packages/agenix_firebase
 
@@ -25,7 +25,7 @@ keywords:
 dependencies:
   flutter:
     sdk: flutter
-  agenix: ^4.1.1
+  agenix: ^4.1.2
   firebase_core: ^4.0.0
   firebase_auth: ^6.0.0
   cloud_firestore: ^6.0.0


### PR DESCRIPTION
# Tool Chain Restriction

## Description
Tools weren't bounded previously. Now we track passed calls, failed calls etc. and only carry forward the failed ones.

## Changes
- [ ] Breaking Change
- [x] Bug Fix
- [ ] Additional Feature
- [ ] Doc updates

## Checklist
- [x] `dart format` clean
- [x] `flutter analyze --fatal-infos` clean
- [x] `flutter test` green; new code covered
- [x] CHANGELOG updated if user-facing
- [x] Public API changes exported from `lib/agenix.dart` and documented

## Issue Linked to the PR
n/a

## Additional Information
n/a